### PR TITLE
Add Commander.js dependency and CLI routing

### DIFF
--- a/bin/gramtap
+++ b/bin/gramtap
@@ -1,4 +1,18 @@
 #!/usr/bin/env node
 
-// Gramtap CLI entry point
-console.log('Gramtap CLI - Coming soon!');
+const { Command } = require('commander');
+const program = new Command();
+
+program
+  .name('gramtap')
+  .description('A developer-friendly CLI for accessing Telegram from the terminal')
+  .version('1.0.0');
+
+program
+  .command('login')
+  .description('Login to Telegram')
+  .action(() => {
+    console.log('Login functionality coming soon!');
+  });
+
+program.parse();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,28 @@
+{
+  "name": "gramtap",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "gramtap",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "commander": "^14.0.0"
+      },
+      "bin": {
+        "gramtap": "bin/gramtap"
+      }
+    },
+    "node_modules/commander": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.0.tgz",
+      "integrity": "sha512-2uM9rYjPvyq39NwLRqaiLtWHyDC1FvryJDa2ATTVims5YAS4PupsEQsDvP14FqhFr0P49CYDugi59xaxJlTXRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -11,8 +11,16 @@
     "test:unit": "echo \"Unit tests not yet implemented\"",
     "test:integration": "echo \"Integration tests not yet implemented\""
   },
-  "keywords": ["telegram", "cli", "terminal", "messaging"],
+  "keywords": [
+    "telegram",
+    "cli",
+    "terminal",
+    "messaging"
+  ],
   "author": "",
   "license": "ISC",
-  "type": "commonjs"
+  "type": "commonjs",
+  "dependencies": {
+    "commander": "^14.0.0"
+  }
 }


### PR DESCRIPTION
- Install commander dependency
- Wire up bin/gramtap to use Commander.js for command routing
- Add placeholder login command with help text
- CLI now shows proper usage and commands with --help

Closes #3